### PR TITLE
Remove placeholder contact info and unused product links

### DIFF
--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -11,20 +11,7 @@ const ContactSection: React.FC = () => {
       <h2 className="section-title mb-12">{t('contact.title')}</h2>
       
       <div className="grid grid-cols-1 md:grid-cols-2 gap-8 md:items-center">
-        <div className="space-y-4">
-          <div className="contact-item">
-            <MapPin size={18} />
-            <p>{t('contact.address')}</p>
-          </div>
-          <div className="contact-item">
-            <Mail size={18} />
-            <p>{t('contact.email')}</p>
-          </div>
-          <div className="contact-item">
-            <Phone size={18} />
-            <p>{t('contact.phone')}</p>
-          </div>
-        </div>
+        <div className="space-y-4" />
         
         <div className="md:justify-self-end md:text-right">
           <a

--- a/src/components/ProductsSection.tsx
+++ b/src/components/ProductsSection.tsx
@@ -73,41 +73,7 @@ const ProductsSection: React.FC = () => {
         </a>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mt-16">
-        <div>
-          <h3 className="text-2xl font-bold mb-2">{t('products.artTitle')}</h3>
-          <p className="text-sm text-gray-600 mb-2">
-            {t('products.artDescription')}
-          </p>
-          <a
-            href="#"
-            className="text-blue-600 underline hover:text-blue-800"
-          >
-            {t('products.artLink')}
-          </a>
-        </div>
-        <div>
-          <h3 className="text-2xl font-bold mb-2">{t('products.nftTitle')}</h3>
-          <p className="text-sm text-gray-600 mb-2">
-            {t('products.nftDescription')}
-          </p>
-          <a
-            href="#"
-            className="text-blue-600 underline hover:text-blue-800"
-          >
-            {t('products.nftLink')}
-          </a>
-        </div>
-      </div>
-
-      <div className="mt-10 text-center">
-        <a
-          href="#"
-          className="inline-block bg-black text-white px-6 py-3 rounded hover:bg-gray-800 transition"
-        >
-          {t('products.cta')}
-        </a>
-      </div>
+      {/* Art and NFT links removed */}
 
       {/* Art and NFT sections have been moved to dedicated components */}
     </section>

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -105,9 +105,6 @@
   },
   "contact": {
     "title": "GET IN TOUCH",
-    "address": "12 AVENUE ST, CITY STATE, COUNTRY 12345",
-    "email": "HELLO@WAUJAPAN.COM",
-    "phone": "+123 456 7890",
     "collaborate": "LET'S WORK TOGETHER",
     "copyright": "© 2025 WAU DESIGNS. ALL RIGHTS RESERVED.",
     "social": {

--- a/src/i18n/locales/ja/translation.json
+++ b/src/i18n/locales/ja/translation.json
@@ -107,9 +107,6 @@
   },
   "contact": {
     "title": "お問い合わせ",
-    "address": "アベニュー12、シティステート、カントリー12345",
-    "email": "HELLO@WAUJAPAN.COM",
-    "phone": "+123 456 7890",
     "collaborate": "協力しましょう",
     "copyright": "© 2025 WAU DESIGNS. 全著作権所有。",
     "social": {

--- a/src/i18n/locales/uk/translation.json
+++ b/src/i18n/locales/uk/translation.json
@@ -88,9 +88,6 @@
   },
   "contact": {
     "title": "ЗВ'ЯЖІТЬСЯ З НАМИ",
-    "address": "ПРОСПЕКТ 12, МІСТО, КРАЇНА 12345",
-    "email": "HELLO@WAUJAPAN.COM",
-    "phone": "+123 456 7890",
     "collaborate": "ДАВАЙТЕ СПІВПРАЦЮВАТИ",
     "copyright": "© 2025 WAU DESIGNS. УСІ ПРАВА ЗАХИЩЕНІ.",
     "social": {


### PR DESCRIPTION
## Summary
- clean up ProductsSection by removing unused art/NFT links
- drop contact address, email, and phone in ContactSection
- strip placeholder contact data from locale files

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685020a88958832386f96d92c1630425