### PR TITLE
Change background to #f8f8f8 and use Raleway font

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:site" content="@lovable_dev" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
     
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Jost:wght@300;400;500;600&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Raleway:wght@300;400;500;600&display=swap">
   </head>
 
   <body>

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Jost:wght@300;400;500;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Raleway:wght@300;400;500;600&display=swap');
 
 @tailwind base;
 @tailwind components;
@@ -6,7 +6,7 @@
 
 @layer base {
   :root {
-    --background: 38 33% 95%;
+    --background: 0 0% 97.3%;
     --foreground: 20 14.3% 4.1%;
 
     --card: 0 0% 100%;
@@ -42,7 +42,7 @@
   }
 
   body {
-    @apply bg-background text-foreground font-jost antialiased;
+    @apply bg-background text-foreground font-raleway antialiased;
   }
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -50,11 +50,12 @@ export default {
 					foreground: 'hsl(var(--card-foreground))'
 				},
 			},
-			fontFamily: {
-				'jost': ['Jost', 'sans-serif'],
-				'cormorant': ['Cormorant Garamond', 'serif'],
-				'lato': ['Lato', 'sans-serif'],
-			},
+                        fontFamily: {
+                                'raleway': ['Raleway', 'sans-serif'],
+                                'jost': ['Jost', 'sans-serif'],
+                                'cormorant': ['Cormorant Garamond', 'serif'],
+                                'lato': ['Lato', 'sans-serif'],
+                        },
 			borderRadius: {
 				lg: 'var(--radius)',
 				md: 'calc(var(--radius) - 2px)',


### PR DESCRIPTION
## Summary
- apply Raleway font sitewide
- update Tailwind config for Raleway
- lighten default background color

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685858344ec883239230fdebf85c8a3a